### PR TITLE
[READY] - Kiosk fix and updates

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -8,7 +8,6 @@
       fsType = "ext4";
     };
   boot = {
-    kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
     loader = {
       generic-extlinux-compatible.enable = lib.mkDefault true;
       grub.enable = lib.mkDefault false;

--- a/base.nix
+++ b/base.nix
@@ -1,7 +1,5 @@
 { pkgs, config, lib, ... }:
 {
-  # This causes an overlay which causes a lot of rebuilding
-  environment.noXlibs = lib.mkForce false;
   # "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix" creates a
   # disk with this label on first boot. Therefore, we need to keep it. It is the
   # only information from the installer image that we need to keep persistent
@@ -15,9 +13,5 @@
       generic-extlinux-compatible.enable = lib.mkDefault true;
       grub.enable = lib.mkDefault false;
     };
-  };
-  nix.settings = {
-    experimental-features = lib.mkDefault "nix-command flakes";
-    trusted-users = [ "root" "@wheel" ];
   };
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,7 +1,8 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   imports = [ ./kiosk.nix ];
-  environment.systemPackages = with pkgs; [ vim git ];
+  # default to stateVersion for current lock
+  system.stateVersion = config.system.nixos.version;
   services.openssh.enable = true;
   networking.hostName = "pi";
   users = {

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, lib, config, ... }:
 {
   imports = [ ./kiosk.nix ];
   # default to stateVersion for current lock
@@ -12,4 +12,10 @@
       extraGroups = [ "wheel" ];
     };
   };
+  nix.settings = {
+    experimental-features = lib.mkDefault "nix-command flakes";
+    trusted-users = [ "root" "@wheel" ];
+  };
+  # This causes an overlay which causes a lot of rebuilding
+  environment.noXlibs = lib.mkForce false;
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,6 +1,9 @@
-{ pkgs, lib, config, ... }:
+{ pkgs, lib, config, modulesPath, ... }:
 {
-  imports = [ ./kiosk.nix ];
+  imports = [
+    ./kiosk.nix
+    "${modulesPath}/profiles/minimal.nix"
+  ];
   # default to stateVersion for current lock
   system.stateVersion = config.system.nixos.version;
   services.openssh.enable = true;
@@ -18,4 +21,6 @@
   };
   # This causes an overlay which causes a lot of rebuilding
   environment.noXlibs = lib.mkForce false;
+
+  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1705312285,
-        "narHash": "sha256-rd+dY+v61Y8w3u9bukO/hB55Xl4wXv4/yC8rCGVnK5U=",
+        "lastModified": 1709147990,
+        "narHash": "sha256-vpXMWoaCtMYJ7lisJedCRhQG9BSsInEyZnnG5GfY9tQ=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "bee2202bec57e521e3bd8acd526884b9767d7fa0",
+        "rev": "33a97b5814d36ddd65ad678ad07ce43b1a67f159",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705316053,
-        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
+        "lastModified": 1709150264,
+        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
+        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696203690,
-        "narHash": "sha256-774XMEL7VHSTLDYVkqrbl5GCdmkVKsjMs+KLM4N4t7k=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "21928e6758af0a258002647d14363d5ffc85545b",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696161939,
-        "narHash": "sha256-HI1DxS//s46/qv9dcW06TzXaBjxL2DVTQP8R1QsnHzM=",
+        "lastModified": 1705312285,
+        "narHash": "sha256-rd+dY+v61Y8w3u9bukO/hB55Xl4wXv4/yC8rCGVnK5U=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "0ab3ee718e964fb42dc57ace6170f19cb0b66532",
+        "rev": "bee2202bec57e521e3bd8acd526884b9767d7fa0",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1686216465,
-        "narHash": "sha256-0A4K6xVIyxUi2YZu4+156WwzAO1GDWGcKiMvsXpBQDQ=",
+        "lastModified": 1698737528,
+        "narHash": "sha256-65qiCQPFGCpdjcfQrO1EZKe+LFD0tzmlecFOACNwMbY=",
         "owner": "Mic92",
         "repo": "nixos-shell",
-        "rev": "65489e7eeef8eeea43e1e4218ad1b99d58852c7c",
+        "rev": "8a835e240adc32e68d6fc7ca5aaf3f597de08d5f",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1705316053,
+        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,15 +20,14 @@
           # more informative?
           x86_64-linux = self.packages.aarch64-linux;
           aarch64-linux = {
-            pi-kiosk-sdImage = (self.nixosConfigurations.pi-kiosk.extendModules {
-              modules = [ "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix" ];
-            }).config.system.build.sdImage;
+            pi-kiosk-sdImage = self.nixosConfigurations.pi-kiosk.config.system.build.sdImage;
           };
         };
         nixosConfigurations = {
           pi-kiosk = nixpkgs.lib.nixosSystem {
             system = "aarch64-linux";
             modules = [
+              "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix"
               nixos-hardware.nixosModules.raspberry-pi-4
               ./configuration.nix
               ./base.nix

--- a/flake.nix
+++ b/flake.nix
@@ -41,12 +41,18 @@
         # x86_64-linux, maybe we should show a trace when building in order to be
         # more informative?
         packages.x86_64-linux.pi-kiosk-sdImage = self.packages.aarch64-linux.pi-kiosk-sdImage;
-        packages.aarch64-linux.pi-kiosk-sdImage = self.nixosConfigurations.pi-kiosk.config.system.build.sdImage;
+        packages.aarch64-linux.pi-kiosk-sdImage = (self.nixosConfigurations.pi-kiosk.extendModules {
+          modules = [
+            "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+            {
+              disabledModules = [ "profiles/base.nix" ];
+            }
+          ];
+        }).config.system.build.sdImage;
         nixosConfigurations = {
           pi-kiosk = nixpkgs.lib.nixosSystem {
             system = "aarch64-linux";
             modules = [
-              "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix"
               nixos-hardware.nixosModules.raspberry-pi-4
               ./configuration.nix
               ./base.nix

--- a/kiosk.nix
+++ b/kiosk.nix
@@ -21,5 +21,8 @@ in
     enable = true;
     user = "kiosk";
     program = kioskProgram;
+    environment = {
+      WLR_LIBINPUT_NO_DEVICES = "1"; # boot up even if no mouse/keyboard connected
+    };
   };
 }

--- a/kiosk.nix
+++ b/kiosk.nix
@@ -7,7 +7,7 @@ let
     # account for ALT+F4 closing window in wayland
     while true
     do
-      if [ -e /sys/class/input/mouse0 ]
+      if [ -e /sys/class/input/mouse1 ]
       then
         # required cross-origin-iframe and popup blocking flags due to iframe
         ${lib.getExe pkgs.chromium} --blink-settings=allowScriptsToCloseWindows=true --ozone-platform=wayland --user-agent="SCALE:1" --disable-popup-blocking --disable-throttle-non-visible-cross-origin-iframes --incognito --start-maximized --disable-gpu --kiosk ${mouseUrl}

--- a/kiosk.nix
+++ b/kiosk.nix
@@ -1,6 +1,6 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 let
-  mouseUrl = "https://register.socallinuxexpo.org/reg6/kiosk/";
+  mouseUrl = "https://register.socallinuxexpo.org/reg6/?kiosk=1";
   regularUrl = "http://signs.scale.lan/";
   kioskProgram = pkgs.writeShellScript "kiosk.sh" ''
     cd /home/kiosk
@@ -10,7 +10,7 @@ let
       if [ -e /sys/class/input/mouse0 ]
       then
         # required cross-origin-iframe and popup blocking flags due to iframe
-        ${lib.getExe pkgs.chromium} --ozone-platform=wayland --disable-popup-blocking --disable-throttle-non-visible-cross-origin-iframes --incognito --start-maximized --disable-gpu --kiosk ${mouseUrl}
+        ${lib.getExe pkgs.chromium} --blink-settings=allowScriptsToCloseWindows=true --ozone-platform=wayland --user-agent="SCALE:1" --disable-popup-blocking --disable-throttle-non-visible-cross-origin-iframes --incognito --start-maximized --disable-gpu --kiosk ${mouseUrl}
       else
         ${lib.getExe pkgs.chromium} --ozone-platform=wayland --incognito --start-maximized --disable-gpu --kiosk ${regularUrl}
       fi
@@ -18,6 +18,20 @@ let
   '';
 in
 {
+  # Disable CTRL keys
+  services.keyd = {
+    enable = true;
+    keyboards = {
+      default = {
+        ids = ["*"];
+        settings = {
+          main = {
+            control = "noop";
+          };
+        };
+      };
+    };
+  };
   users.users.kiosk = {
     isNormalUser = true;
     password = "changeme";

--- a/kiosk.nix
+++ b/kiosk.nix
@@ -1,14 +1,20 @@
 { pkgs, lib, ... }:
 let
-  mouseUrl = "https://google.com";
-  regularUrl = "https://duckduckgo.com";
+  mouseUrl = "https://register.socallinuxexpo.org/reg6/kiosk/";
+  regularUrl = "http://signs.scale.lan/";
   kioskProgram = pkgs.writeShellScript "kiosk.sh" ''
-    if [ -e /sys/class/input/mouse0 ]
-    then
-      ${lib.getExe pkgs.chromium} --disable-infobars --start-maximized --kiosk ${mouseUrl}
-    else
-      ${lib.getExe pkgs.chromium} --disable-infobars --start-maximized --kiosk ${regularUrl}
-    fi
+    cd /home/kiosk
+    # account for ALT+F4 closing window in wayland
+    while true
+    do
+      if [ -e /sys/class/input/mouse0 ]
+      then
+        # required cross-origin-iframe and popup blocking flags due to iframe
+        ${lib.getExe pkgs.chromium} --ozone-platform=wayland --disable-popup-blocking --disable-throttle-non-visible-cross-origin-iframes --incognito --start-maximized --disable-gpu --kiosk ${mouseUrl}
+      else
+        ${lib.getExe pkgs.chromium} --ozone-platform=wayland --incognito --start-maximized --disable-gpu --kiosk ${regularUrl}
+      fi
+    done
   '';
 in
 {


### PR DESCRIPTION
## Description

Upon building the current image off `master` cage doesnt launch chromium. The following changes correct the behavior and
add some additional configuration to confirm that this works with the reg URL.

chromium flag `--disable-infobars` seems have been deprecated a while back so removing that since it doesnt seem to be effecting anything.

~~**UPDATE** Hold off on this for now, a net new image didnt work. Getting a core dump on the cage service and when running it manually it has a `error: EGL_BAD_PARAMETER (0x300c), message: "eglQueryDeviceStringEXT"`~~

**UPDATE 2/16/24** Figured out the issue with cage and launching the browser. This is currently fixed thanks to https://github.com/NixOS/nixpkgs/issues/229235 specifically:  https://github.com/NixOS/nixpkgs/issues/229235#issuecomment-1937393274

Ive opted to keep chromium since its was easier to work around the issues of displaying the registration iframe. It seems to be working to the best of my knowledge with the image which previously was having issues.

## Testing

Process for confirming this works a expected: 
- Build the image
- Copy image to SD card
- Check the following states:
    - Boot RPi with keyboard and network
    - Boot RPi without keyboard and with network
    - Boot RPi with keyboard and without network
    - Boot RPi without keyboard and without network
