### PR TITLE
[WIP] [SN-772] - kanshi display config management

### DIFF
--- a/kanshi.nix
+++ b/kanshi.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+
+{
+  environment.systemPackages = with pkgs; [ kanshi ];
+  systemd.services.kanshi = {
+    description = "kanshi dynamic display congfiguration daemon";
+    wantedBy = [ "graphical.target" ];
+    partOf = [ "graphical.target" ];
+    after = [ "cage-tty1.target" ];
+    environment.XDG_RUNTIME_DIR = "/run/user/1000";
+    environment.WAYLAND_DISPLAY = "wayland-0";
+    serviceConfig = {
+      Type = "simple";
+      User = "kiosk";
+      ExecStart = ''${pkgs.kanshi}/bin/kanshi -c /etc/kanshi/config'';
+    };
+  };
+  environment.etc."kanshi/config" = {
+    text = ''
+      output * mode 7680x4320 scale 3
+      output * mode 3840x2160 scale 2
+      output * mode 1920x1080 scale 1
+      output * scale 1
+    '';
+    mode="0644";
+  };
+}

--- a/kiosk.nix
+++ b/kiosk.nix
@@ -21,6 +21,9 @@ let
   '';
 in
 {
+  imports = [
+    ./kanshi.nix
+  ];
   # Disable CTRL keys
   services.keyd = {
     enable = true;


### PR DESCRIPTION
In issue https://github.com/socallinuxexpo/scale-network/issues/772, we capture a need to manage display resolution dynamically.  I've experimented with Kanshi a bit on my personal machine and I'm fairly confident it can work for our needs on these kiosks and signs implemented on raspberry pi.

I'm marking this as a [WIP] until I'm able to build the raspberry pi image and test it locally.