### PR TITLE
allow args to be passed to nix run .#vm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,8 @@
             # screw up the clock so that a lack of RTC be emulated in VM
             ${pkgs.lib.getExe vmScript} \
               -serial stdio \
-              -rtc base=1970-01-01T12:12:12,clock=vm,driftfix=slew
+              -rtc base=1970-01-01T12:12:12,clock=vm,driftfix=slew \
+              "$@"
           '');
         };
       };


### PR DESCRIPTION
Allows passing QEMU flags through to our VM script such as this:

`nix run .#vm -- -display sdl,gl=on -device qxl-vga,xres=7680,yres=4320`