### PR TITLE
enable zram

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -84,4 +84,10 @@
   # Reduces closure size
   nixpkgs.flake.setFlakeRegistry = false;
   nixpkgs.flake.setNixPath = false;
+
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 90;
+  };
 }


### PR DESCRIPTION
Makes resource-constrained situations much more graceful, and allows testing of 8K displays in VMs possible with less memory. Win win.