### PR TITLE
Dynamically DPI based on monitor resolution via wlr-randr

### DIFF
--- a/kiosk.nix
+++ b/kiosk.nix
@@ -50,4 +50,52 @@ in
       WLR_LIBINPUT_NO_DEVICES = "1"; # boot up even if no mouse/keyboard connected
     };
   };
+  systemd.services.dynamic-scale = let
+    dynamic-scale = pkgs.writeShellScript "dynamic-scale.sh" ''
+      set -x
+      # Get the JSON output from wlr-randr
+      output_json=$(wlr-randr --json)
+      # Use jq to find outputs and their resolutions
+      echo "$output_json" | jq -c '.[] | {name: .name, height: .modes[0].height}' | while read -r output; do
+          # Extract monitor name and height
+          name=$(echo "$output" | jq -r '.name')
+          height=$(echo "$output" | jq -r '.height')
+          # Calculate scale dynamically based on height
+          if [ "$height" -ge 1080 ]; then
+              scale=1.0
+          fi
+          if [ "$height" -ge 1440 ]; then
+              scale=1.33
+          fi
+          if [ "$height" -ge 2160 ]; then
+              scale=2.0
+          fi
+          if [ "$height" -ge 4320 ]; then
+              scale=4.0
+          fi
+          # Apply the scale
+          echo "Setting scale $scale for $name (height: $height)"
+          wlr-randr --output "$name" --scale "$scale"
+      done
+    '';
+  in {
+    description = "Dynamically Configure DPI based on Resolution";
+    wantedBy = [ "graphical.target" ];
+    partOf = [ "graphical.target" ];
+    after = [ "cage-tty1.service" ];
+    path = with pkgs; [ wlr-randr jq ];
+
+    # Probably possible to do this with systemd user services instead
+    # https://www.baeldung.com/linux/systemd-session-dbus-headless-setup
+    environment.XDG_RUNTIME_DIR = "/run/user/1000";
+    environment.WAYLAND_DISPLAY = "wayland-0";
+
+    serviceConfig = {
+      Type = "simple";
+      User = "kiosk";
+      ExecStart = "${dynamic-scale}";
+      Restart = "always";
+      RestartSec = 5;
+    };
+  };
 }


### PR DESCRIPTION
Completes https://github.com/socallinuxexpo/scale-kiosk/pull/8

This is a script that scans through every monitor, and if their pixels are greater or equal to preset sizes, it will increase the DPI/Scale using wlr-randr.

Here's 4 VMs with the resolution(s) 1080p (1.0), 1440p(1.33), 2160p(2.0), 4320p(4.0), and their fractional scaling perfectly set.

These can be spawned and verified as follows:

```
nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=7680,yres=4320,vgamem_mb=512 &
nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=3840,yres=2160,vgamem_mb=512 &
nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=2560,yres=1440,vgamem_mb=512 &
nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=1920,yres=1080,vgamem_mb=512 &
```

![image](https://github.com/user-attachments/assets/3ed1e06f-25c0-48d5-b982-16a33416a5c0)
