### PR TITLE
configuration.nix: update root password for 22x

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,14 @@ arm64 machine for every package/derivation that needs to be compiled. Binfmt is
 a kernel feature that will allows programs like QEMU to be span up whenever any
 program tries to spawn a process for a foreign architecture.
 
+## Testing
+
+Verify the resolution(s) 1080p (1.0), 1440p(1.33), 2160p(2.0), 4320p(4.0) using vmTests:
+
+```
+nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=7680,yres=4320,vgamem_mb=512 &
+nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=3840,yres=2160,vgamem_mb=512 &
+nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=2560,yres=1440,vgamem_mb=512 &
+nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=1920,yres=1080,vgamem_mb=512 &
+```
+> This confirms is working as expected

--- a/configuration.nix
+++ b/configuration.nix
@@ -61,7 +61,7 @@
   };
 
   users.mutableUsers = false;
-  users.extraUsers.root.hashedPassword = "$6$3Hm/K5fbR3UEMK6H$3aaegtdwvejGk9Bk0ttN5bNJn4z2Yt6LWXD3nGI7.44Pbm7A1TpKuxG9XQLwsj7M9NEk8eB5Exg0qVRV//6br/";
+  users.extraUsers.root.hashedPassword = "$6$fdmMoUSxXGhjJYKK$iy8CUzXICDhssjiQN53/juZfxqGg/KbKf60M.tho2HUcFWnvmnhAEx55SwQWzTiI2rfnLA9Xlbz.vweS/8LD9.";
 
   nix.settings = {
     experimental-features = lib.mkDefault "nix-command flakes";


### PR DESCRIPTION
## Description

This matches what the root password is for the servers for 22x and had some docs to the readme from the testing done in: https://github.com/socallinuxexpo/scale-kiosk/pull/13

## Tests

- Confirmed I was able to login via the expected root password in the vmTest:

```
$ nix run .#vm -- -display sdl,gl=off -device qxl-vga,xres=7680,yres=4320,vgamem_mb=512
warning: Git tree '/home/rherna/workspace/scale-kiosk' is dirty
Disk image do not exist, creating the virtualisation disk image...
Formatting '/tmp/tmp.JhGeSsriA7', fmt=raw size=1073741824
mke2fs 1.47.0 (5-Feb-2023)
Discarding device blocks: done
Creating filesystem with 262144 4k blocks and 65536 inodes
Filesystem UUID: af6fb1a6-2bf4-438f-ad31-939cb0f0fdc1
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376

Allocating group tables: done
Writing inode tables: done
Creating journal (8192 blocks): done
Writing superblocks and filesystem accounting information: done

Virtualisation disk image created.


<<< Welcome to NixOS 24.05.20240228.9099616 (x86_64) - ttyS0 >>>


pi login: root
Password:

[root@pi:~]#
```
