### PR TITLE
Lldp and eui64

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -101,6 +101,7 @@
   # Allows us to calculate the v6 addresses from mac addresses (EUI-64)
   networking.tempAddresses = "disabled";
 
+  networking.useDHCP = false;
   systemd.network = {
     enable = true;
     networks = {
@@ -108,6 +109,7 @@
         name = "e*0*";
         enable = true;
         networkConfig = {
+          DHCP = "yes";
           LLDP = true;
           EmitLLDP = true;
           IPv6PrivacyExtensions = false;


### PR DESCRIPTION
Fixes: https://github.com/socallinuxexpo/scale-network/issues/934

Enables LLDP on end0 and disables temp addressing which allows us to use EUI64 to get the addresses of the Pi's 