### PR TITLE
bump go-signs (unified data structure)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769293048,
-        "narHash": "sha256-QP0bq+e58Zv/7gUc8N5rrItKgacb8mrijNwCZHdZR6Y=",
+        "lastModified": 1770829675,
+        "narHash": "sha256-WpywdXbgxs9Pza0yID/qtuuaZAXcSMLOVa1rFGE/fqM=",
         "owner": "kylerisse",
         "repo": "go-signs",
-        "rev": "a7042b8a5049165fa23be0f33c5dd6595723e4f3",
+        "rev": "fa9e7b52e0c158873a2735c0f3f85c26df00ac76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- bump `go-signs` to a version that has breaking changes if being used with `scale-simulator`. This fixes the testing method used below.

1. Setup uncommitted temporary changes

`go-signs.nix`
```
-    ExecStart = "${inputs.go-signs.packages.${pkgs.hostPlatform.system}.go-signs}/bin/go-signs";
+    ExecStart = "${inputs.go-signs.packages.${pkgs.hostPlatform.system}.go-signs}/bin/go-signs -json https://simulator.go-signs.org/sign.json";
```

`kisok.nix`
```
-  mouseUrl = "https://register.socallinuxexpo.org/reg6/?kiosk=1";
+  mouseUrl = "http://127.0.0.1:2017";
```

2. `nix run .#vm` and view gui, looks good and matches what I expect
3. login to the vm and `curl http://localhost:2017/schedule` and confirm `Speakers` is a string and not list
