### PR TITLE
inputs: bump go-signs for no mouse cursor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1770829675,
-        "narHash": "sha256-WpywdXbgxs9Pza0yID/qtuuaZAXcSMLOVa1rFGE/fqM=",
+        "lastModified": 1771448694,
+        "narHash": "sha256-Pyv/zNVhAZgl/bPKQZTkrvDiirQG0YcRWOtatGo3FqE=",
         "owner": "kylerisse",
         "repo": "go-signs",
-        "rev": "fa9e7b52e0c158873a2735c0f3f85c26df00ac76",
+        "rev": "1273cf37e92f322726bfb45f94ffe605df715da6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
@MatthewCroughan found an issue where the mouse cursor would appear even without one plugged in. This was resolved on the `go-signs` side by setting CSS to hide the mouse cursor. This PR brings that change into `scale-kiosk`.

Tests:

1. my standard testing diff and verified with `nix run .#vm`

```
-    ExecStart = "${inputs.go-signs.packages.${pkgs.hostPlatform.system}.go-signs}/bin/go-signs";
+    ExecStart = "${inputs.go-signs.packages.${pkgs.hostPlatform.system}.go-signs}/bin/go-signs -json=https://simulator.go-signs.org/sign.json";

-  mouseUrl = "https://register.socallinuxexpo.org/reg6/?kiosk=1";
+  mouseUrl = "http://127.0.0.1:2017";
```