### PR TITLE
use --app=<url> for regularUrl

### DIFF
--- a/kiosk.nix
+++ b/kiosk.nix
@@ -15,7 +15,7 @@ let
         # required cross-origin-iframe and popup blocking flags due to iframe
         ${lib.getExe pkgs.ungoogled-chromium} --blink-settings=allowScriptsToCloseWindows=true --user-agent="SCALE:$LAST_OCTET" --disable-popup-blocking --disable-throttle-non-visible-cross-origin-iframes --incognito --start-maximized --disable-gpu --kiosk --app='${mouseUrl}'
       else
-        ${lib.getExe pkgs.ungoogled-chromium} --incognito --start-maximized --disable-gpu --kiosk ${regularUrl}
+        ${lib.getExe pkgs.ungoogled-chromium} --incognito --start-maximized --disable-gpu --kiosk --app='${regularUrl}'
       fi
     done
   '';


### PR DESCRIPTION
Just something we missed, without this it will show the title bar in the browser which is unwanted

Specifically for signs condition:
```
`--app` is now needed for both since `--kiosk` isn't enough anymore in 2026
```